### PR TITLE
Updated opam

### DIFF
--- a/opam
+++ b/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Leo White <leo@lpw25.net>"
+authors: ["Leo White <leo@lpw25.net>"]
+homepage: "https://github.com/lpw25/async_graphics"
+bug-reports: "https://github.com/lpw25/async_graphics/issues"
+dev-repo: "https://github.com/lpw25/async_graphics.git"
+license: "LGPL-2.0 with OCaml linking exception"
+tags: [
+  "async"
+  "graphics"
+]
+remove: [["ocamlfind" "remove" "async_graphics"]]
+depends: [
+  "ocamlfind"
+  "graphics"
+  "async" {>= "109.09.00" & < "v0.12"}
+  "ocamlbuild" {build}
+]
+install: "./install.sh"


### PR DESCRIPTION
This package is needed to make one RWO example. If we want to have a recent version of OCaml and of Core we need to update the opam file.